### PR TITLE
Input fields are disabled in Mozilla

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,6 +1,6 @@
 function ilw_initialize_sortable(){
 	jQuery( '.ilw_sortable' ).sortable();
-	jQuery( '.ilw_sortable' ).disableSelection();
+	//jQuery( '.ilw_sortable' ).disableSelection();
 
 	jQuery('.ilw_widget .widget-title-action, .ilw_widget .widget-title-action a').unbind();
 


### PR DESCRIPTION
disableSelection causes an issue in Mozilla where you not able to edit the input fields